### PR TITLE
fix: resolve golangci-lint gofmt and modernize issues

### DIFF
--- a/intent.go
+++ b/intent.go
@@ -1,6 +1,9 @@
 package seiconfig
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // ConfigIntent declares the desired configuration state for a Sei node.
 // It is the portable contract between the controller, sidecar, and CLI.
@@ -215,14 +218,7 @@ func validateIntentRequiredFields(result *ConfigResult, intent ConfigIntent, reg
 		if len(field.RequiredForModes) == 0 {
 			continue
 		}
-		required := false
-		for _, m := range field.RequiredForModes {
-			if m == intent.Mode {
-				required = true
-				break
-			}
-		}
-		if !required {
+		if !slices.Contains(field.RequiredForModes, intent.Mode) {
 			continue
 		}
 

--- a/legacy.go
+++ b/legacy.go
@@ -105,9 +105,9 @@ type legacyMempool struct {
 }
 
 type legacyStateSync struct {
-	Enable                    bool   `toml:"enable"`
-	UseP2P                    bool   `toml:"use-p2p"`
-	RPCServers                string `toml:"rpc-servers"`
+	Enable                    bool     `toml:"enable"`
+	UseP2P                    bool     `toml:"use-p2p"`
+	RPCServers                string   `toml:"rpc-servers"`
 	TrustHeight               int64    `toml:"trust-height"`
 	TrustHash                 string   `toml:"trust-hash"`
 	TrustPeriod               Duration `toml:"trust-period"`


### PR DESCRIPTION
## Summary
- Fix `gofmt` alignment in `legacyStateSync` struct fields (`legacy.go`)
- Replace manual loop with `slices.Contains` in `validateIntentRequiredFields` (`intent.go`)

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` passes