### PR TITLE
feat: add well-known port constants and NodePorts()

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,36 @@ const CurrentVersion = 1
 // creation interval (in blocks) used when snapshot generation is enabled.
 const DefaultSnapshotInterval = 2000
 
+// Well-known default ports for Sei node services and the sidecar.
+const (
+	PortEVMHTTP int32 = 8545
+	PortEVMWS   int32 = 8546
+	PortGRPC    int32 = 9090
+	PortP2P     int32 = 26656
+	PortRPC     int32 = 26657
+	PortMetrics int32 = 26660
+	PortSidecar int32 = 7777
+)
+
+// NodePort pairs a human-readable service name with its default port number.
+type NodePort struct {
+	Name string
+	Port int32
+}
+
+// NodePorts returns the canonical set of ports exposed by a Sei node (seid).
+// The sidecar port is excluded; use PortSidecar directly.
+func NodePorts() []NodePort {
+	return []NodePort{
+		{"evm-rpc", PortEVMHTTP},
+		{"evm-ws", PortEVMWS},
+		{"grpc", PortGRPC},
+		{"p2p", PortP2P},
+		{"rpc", PortRPC},
+		{"metrics", PortMetrics},
+	}
+}
+
 // Pruning strategy constants.
 const (
 	PruningDefault    = "default"

--- a/defaults.go
+++ b/defaults.go
@@ -139,9 +139,9 @@ func baseDefaults() *SeiConfig {
 
 		EVM: EVMConfig{
 			HTTPEnabled:                  true,
-			HTTPPort:                     8545,
+			HTTPPort:                     int(PortEVMHTTP),
 			WSEnabled:                    true,
-			WSPort:                       8546,
+			WSPort:                       int(PortEVMWS),
 			ReadTimeout:                  Dur(30 * time.Second),
 			ReadHeaderTimeout:            Dur(30 * time.Second),
 			WriteTimeout:                 Dur(30 * time.Second),


### PR DESCRIPTION
## Summary
- Adds typed `int32` port constants (`PortRPC`, `PortP2P`, `PortGRPC`, `PortEVMHTTP`, `PortEVMWS`, `PortMetrics`, `PortSidecar`) so consumers like `sei-k8s-controller` can reference canonical values instead of maintaining duplicate magic numbers.
- Adds `NodePort` type and `NodePorts()` function returning the name→port pairs needed for Kubernetes container/service port generation.
- Updates `baseDefaults()` EVM config to use `PortEVMHTTP`/`PortEVMWS` instead of bare `8545`/`8546` literals.

## Test plan
- [x] Existing `sei-config` tests pass (no behavioral change, just new exports + literal dedup)
- [x] `sei-k8s-controller` builds against this branch using `go.work` and its `resources.go` / `resources_test.go` now reference `seiconfig.PortSidecar` and `seiconfig.NodePorts()`