### PR TITLE
feat(evm): add EnabledLegacySeiApis to EVMConfig schema

### DIFF
--- a/config.go
+++ b/config.go
@@ -391,6 +391,11 @@ type EVMConfig struct {
 
 	DenyList []string `toml:"deny_list"`
 
+	// EnabledLegacySeiApis lists deprecated sei_* / sei2_* JSON-RPC methods
+	// the EVM HTTP endpoint will serve. Empty disables the legacy namespace
+	// entirely. The namespace is scheduled for removal; use eth_* methods.
+	EnabledLegacySeiApis []string `toml:"enabled_legacy_sei_apis"`
+
 	MaxLogNoBlock           int64  `toml:"max_log_no_block"`
 	MaxBlocksForLog         int64  `toml:"max_blocks_for_log"`
 	MaxSubscriptionsNewHead uint64 `toml:"max_subscriptions_new_head"`

--- a/config.go
+++ b/config.go
@@ -391,9 +391,6 @@ type EVMConfig struct {
 
 	DenyList []string `toml:"deny_list"`
 
-	// EnabledLegacySeiApis lists deprecated sei_* / sei2_* JSON-RPC methods
-	// the EVM HTTP endpoint will serve. Empty disables the legacy namespace
-	// entirely. The namespace is scheduled for removal; use eth_* methods.
 	EnabledLegacySeiApis []string `toml:"enabled_legacy_sei_apis"`
 
 	MaxLogNoBlock           int64  `toml:"max_log_no_block"`

--- a/config_test.go
+++ b/config_test.go
@@ -535,6 +535,43 @@ func TestApplyOverrides_StringSliceOverwritesDefault(t *testing.T) {
 	}
 }
 
+// TestStringSliceMissingKeyDecodesAsNil locks the asymmetry between
+// "field absent in app.toml" and "field present as empty list":
+//
+//	nil          -> key omitted from written TOML -> reads back as nil
+//	[]string{}   -> "field = []" in written TOML  -> reads back as []string{}
+//
+// Downstream consumers branching on nil vs non-nil-empty (e.g. "was this
+// configured at all?") rely on this. BurntSushi/toml v1.5.0 honors the
+// distinction; a future encoder change that normalized nil and empty
+// would silently break that branch.
+func TestStringSliceMissingKeyDecodesAsNil(t *testing.T) {
+	cfg := DefaultForMode(ModeFull)
+	cfg.EVM.EnabledLegacySeiApis = nil
+
+	dir := t.TempDir()
+	if err := WriteConfigToDir(cfg, dir); err != nil {
+		t.Fatalf("WriteConfigToDir: %v", err)
+	}
+
+	appToml, err := os.ReadFile(filepath.Join(dir, "config", "app.toml"))
+	if err != nil {
+		t.Fatalf("read app.toml: %v", err)
+	}
+	if strings.Contains(string(appToml), "enabled_legacy_sei_apis") {
+		t.Errorf("nil slice should be omitted from app.toml; got it written")
+	}
+
+	loaded, err := ReadConfigFromDir(dir)
+	if err != nil {
+		t.Fatalf("ReadConfigFromDir: %v", err)
+	}
+	if loaded.EVM.EnabledLegacySeiApis != nil {
+		t.Errorf("missing key should decode as nil; got %v (len %d)",
+			loaded.EVM.EnabledLegacySeiApis, len(loaded.EVM.EnabledLegacySeiApis))
+	}
+}
+
 func TestApplyOverrides_StringSliceRoundTripTOML(t *testing.T) {
 	dir := t.TempDir()
 

--- a/config_test.go
+++ b/config_test.go
@@ -609,6 +609,17 @@ func TestResolveEnv_LegacyPrefix(t *testing.T) {
 	}
 }
 
+func TestResolveEnv_StringSlice(t *testing.T) {
+	cfg := Default()
+	t.Setenv("SEI_EVM_ENABLED_LEGACY_SEI_APIS", "sei_getLogs,sei_getBlockByNumber")
+
+	ResolveEnv(cfg)
+	got := cfg.EVM.EnabledLegacySeiApis
+	if len(got) != 2 || got[0] != "sei_getLogs" || got[1] != "sei_getBlockByNumber" {
+		t.Errorf("after ResolveEnv: got %v, want [sei_getLogs sei_getBlockByNumber]", got)
+	}
+}
+
 func TestResolveEnv_SEIPrecedence(t *testing.T) {
 	cfg := Default()
 	t.Setenv("SEI_CHAIN_MIN_GAS_PRICES", "0.5usei")

--- a/config_test.go
+++ b/config_test.go
@@ -227,6 +227,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	// so it does not round-trip through the legacy two-file format.
 	original.Chain.Moniker = "test-node"
 	original.EVM.HTTPPort = 9545
+	original.EVM.EnabledLegacySeiApis = []string{"sei_getLogs", "sei_getBlockByNumber"}
 	original.Storage.StateStore.KeepRecent = 50000
 
 	if err := WriteConfigToDir(original, dir); err != nil {
@@ -252,6 +253,10 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	}
 	if loaded.EVM.HTTPPort != 9545 {
 		t.Errorf("evm.http_port: got %d, want 9545", loaded.EVM.HTTPPort)
+	}
+	if got := loaded.EVM.EnabledLegacySeiApis; len(got) != 2 ||
+		got[0] != "sei_getLogs" || got[1] != "sei_getBlockByNumber" {
+		t.Errorf("evm.enabled_legacy_sei_apis: got %v, want [sei_getLogs sei_getBlockByNumber]", got)
 	}
 	if loaded.Storage.StateStore.KeepRecent != 50000 {
 		t.Errorf("state_store.keep_recent: got %d, want 50000", loaded.Storage.StateStore.KeepRecent)

--- a/defaults.go
+++ b/defaults.go
@@ -161,6 +161,7 @@ func baseDefaults() *SeiConfig {
 			CheckTxTimeout:               Dur(5 * time.Second),
 			MaxTxPoolTxs:                 1000,
 			DenyList:                     []string{},
+			EnabledLegacySeiApis:         []string{},
 			MaxLogNoBlock:                10_000,
 			MaxBlocksForLog:              2000,
 			MaxSubscriptionsNewHead:      10_000,

--- a/enrichments.go
+++ b/enrichments.go
@@ -295,6 +295,9 @@ func DefaultEnrichments() map[string][]FieldOption {
 			WithDescription("RPC methods that should immediately fail (e.g. debug_traceBlockByNumber)."),
 			WithHotReload(),
 		},
+		"evm.enabled_legacy_sei_apis": {
+			WithDescription("Deprecated sei_*/sei2_* JSON-RPC methods served on the EVM HTTP endpoint."),
+		},
 		"evm.max_log_no_block": {
 			WithDescription("Maximum logs returned when block range is open-ended."),
 		},

--- a/legacy.go
+++ b/legacy.go
@@ -311,6 +311,7 @@ type legacyEVM struct {
 	MaxTxPoolTxs                 uint64   `toml:"max_tx_pool_txs"`
 	Slow                         bool     `toml:"slow"`
 	DenyList                     []string `toml:"deny_list"`
+	EnabledLegacySeiApis         []string `toml:"enabled_legacy_sei_apis"`
 	MaxLogNoBlock                int64    `toml:"max_log_no_block"`
 	MaxBlocksForLog              int64    `toml:"max_blocks_for_log"`
 	MaxSubscriptionsNewHead      uint64   `toml:"max_subscriptions_new_head"`
@@ -628,6 +629,7 @@ func (cfg *SeiConfig) toLegacyApp() legacyAppConfig {
 			MaxTxPoolTxs:                 cfg.EVM.MaxTxPoolTxs,
 			Slow:                         cfg.EVM.Slow,
 			DenyList:                     cfg.EVM.DenyList,
+			EnabledLegacySeiApis:         cfg.EVM.EnabledLegacySeiApis,
 			MaxLogNoBlock:                cfg.EVM.MaxLogNoBlock,
 			MaxBlocksForLog:              cfg.EVM.MaxBlocksForLog,
 			MaxSubscriptionsNewHead:      cfg.EVM.MaxSubscriptionsNewHead,
@@ -895,6 +897,7 @@ func fromLegacy(tm legacyTendermintConfig, app legacyAppConfig) *SeiConfig {
 			MaxTxPoolTxs:                 app.EVM.MaxTxPoolTxs,
 			Slow:                         app.EVM.Slow,
 			DenyList:                     app.EVM.DenyList,
+			EnabledLegacySeiApis:         app.EVM.EnabledLegacySeiApis,
 			MaxLogNoBlock:                app.EVM.MaxLogNoBlock,
 			MaxBlocksForLog:              app.EVM.MaxBlocksForLog,
 			MaxSubscriptionsNewHead:      app.EVM.MaxSubscriptionsNewHead,

--- a/registry_test.go
+++ b/registry_test.go
@@ -86,6 +86,7 @@ func TestBuildRegistry_FieldTypes(t *testing.T) {
 		{"mempool.drop_priority_threshold", FieldTypeFloat},
 		{"network.rpc.timeout_broadcast_tx_commit", FieldTypeDuration},
 		{"tx_index.indexer", FieldTypeStringSlice},
+		{"evm.enabled_legacy_sei_apis", FieldTypeStringSlice},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Follow-up to #14. Adds the schema field that motivated the slice-override work.

## Summary

Mirrors `sei-chain/evmrpc/config/config.go:143` (`EnabledLegacySeiApis []string` with toml tag `enabled_legacy_sei_apis`). This is the schema field that maps to `[evm].enabled_legacy_sei_apis` in `app.toml` — the allowlist that gates deprecated `sei_*` / `sei2_*` JSON-RPC methods.

Without this field, `ApplyOverrides` rejects `evm.enabled_legacy_sei_apis` as `"unknown override key"` because `BuildRegistry` only sees fields that exist on `SeiConfig`. Combined with #14 (slice override support), this enables per-chain control of the legacy namespace via the SND `spec.template.spec.overrides` map.

## Default

`[]string{}` — legacy namespace disabled. Matches the upstream sei-chain default and the production stance. Per-chain enablement is a deliberate `overrides` action, not opt-out.

## Wired through

- `config.go` — `EnabledLegacySeiApis []string` field on `EVMConfig` adjacent to `DenyList`.
- `legacy.go` — same field on `legacyEVM` with matching toml tag, plus mapping in `toLegacyApp` (write) and `fromLegacy` (read), preserving the round-trip contract enforced by `TestWriteReadRoundTrip_AllModes`.
- `defaults.go` — explicit `[]string{}` in `baseDefaults` so the field renders as `enabled_legacy_sei_apis = []` in served TOML rather than being omitted.
- `registry_test.go` — adds `evm.enabled_legacy_sei_apis` to the `FieldTypeStringSlice` classification check.
- `config_test.go` — extends `TestWriteReadRoundTrip` to set the field to `["sei_getLogs", "sei_getBlockByNumber"]` and assert it survives the legacy two-file write/read cycle.

## Verification

- `go test -count=1 ./...` — green.
- `TestWriteReadRoundTrip_AllModes` exercises the new default through every `NodeMode` automatically.

## Out of scope

- Bumping seictl's go.mod to a `sei-config` release containing this field. Separate PR after this lands and gets tagged.
- Setting the override in the seictl `genesis-chain` / `rpc` presets. Separate PR.