### PR TITLE
docs: design for sei-chain configuration manager

### DIFF
--- a/docs/config-manager/DESIGN.md
+++ b/docs/config-manager/DESIGN.md
@@ -11,7 +11,7 @@ The **sei-config library already exists and is the asset**: unified `SeiConfig`,
 ## Goals
 
 - An **env-var-gated** path in `seid` that resolves config through the sei-config library instead of the legacy loader. Default off; legacy path byte-for-byte unchanged.
-- An in-binary `seid config …` command group (urfave/cli v3) exposing the library's existing capabilities: `doctor` (validate), `generate --mode` (node-type defaults), `migrate` (schema versioning).
+- An in-binary `seid config …` command group exposing the library's existing capabilities: `doctor` (validate), `generate --mode` (node-type defaults), `migrate` (schema versioning). *(Framework + cobra coexistence: see Decision.)*
 - A versioning contract that lets a config be migrated safely across `seid` releases.
 - Keep all changes **inside the sei-chain repo proper** — touch zero lines of the `sei-cosmos` fork.
 
@@ -25,7 +25,13 @@ The **sei-config library already exists and is the asset**: unified `SeiConfig`,
 
 ## ⚠️ Decision: the CLI surface is an in-binary `seid config …` group (urfave/cli v3)
 
-The management UX (`doctor`/`generate`/`migrate`/`show`) ships **inside the `seid` binary** as a `seid config …` command group on urfave/cli v3 — not a separate `seictl`. One binary, one home for config logic, consistent with seid eventually owning its own config. **Open tension (for cross-review):** seid's root is cobra, so a single cobra command must delegate its args to a urfave `cli.Command`; that boundary (help, flag parsing, completion) is what the next review must validate — earlier review flagged cobra↔urfave coexistence as a real cost, and choosing urfave in-binary accepts it deliberately. The runtime *seam* (below) is unaffected: pure library calls, no CLI framework.
+The management UX (`doctor`/`generate`/`migrate`/`show`) ships **inside the `seid` binary** as a `seid config …` command group on urfave/cli v3 — not a separate `seictl`. One binary, one home for config logic, consistent with seid eventually owning its own config; it also kills CLI-vs-node version skew (the migration tool *is* the node binary). Cross-review settled the cobra↔urfave coexistence:
+
+- **`config` skips the persistent prerun.** `PersistentPreRunE` runs for every subcommand; without a guard `seid config …` would trigger `InterceptConfigsPreRunHandler` (and under `SEI_CONFIG_MANAGER=v2`, the gated seam *recursively*) — mutating files just to inspect them. Extend the `init` skip at `root.go:97` to also short-circuit `config`.
+- **Delegation:** one `config` cobra command with `DisableFlagParsing: true` (already used at `root.go:176,200`) hands the raw arg tail to urfave; urfave owns only the `config` subtree, never global flags. Errors propagate via `RunE` to `main.go`'s `os.Exit`; urfave's exit handler is a no-op.
+- **Accepted costs:** go.mod already carries urfave/cli **v2**; v3 adds a second major version (deliberate). Completion can't introspect a `DisableFlagParsing` subtree, so `config` won't autocomplete (deferred).
+
+The runtime *seam* (below) is otherwise unaffected: pure library calls, no CLI framework.
 
 ## Architecture — two repos
 
@@ -33,7 +39,7 @@ The management UX (`doctor`/`generate`/`migrate`/`show`) ships **inside the `sei
 |---|---|---|
 | `seiconfig` library | sei-config | The brain — exists today. Resolution, modes, validate, migrate, legacy IO. **Imported as a dependency** by sei-chain. |
 | Env-gated seam | sei-chain | `PersistentPreRunE` hook routing config through the library when gated on. |
-| `seid config …` CLI | sei-chain | In-binary operator/CI surface (urfave/cli v3): `doctor \| generate \| migrate \| show`. |
+| `seid config …` CLI | sei-chain | In-binary operator/CI surface: `doctor \| generate \| migrate \| show`. |
 
 **Future: fold-in.** There's a real chance sei-config later collapses into the sei-chain tree so seid owns its own config outright. Because the dependency arrow points only sei-chain → sei-config (never back), that's a `git mv` + import-path change — **the seam contract is unchanged**. Reversible; the only discipline is keeping sei-config a clean leaf (minimal deps, no seid coupling), which CLAUDE.md already mandates.
 
@@ -66,7 +72,7 @@ In: the gate + seam (both channels populated); the collision audit; a **fidelity
 
 ## Deferred (with un-defer trigger)
 
-- **`seid config …` CLI (urfave/cli v3)** → once the seam is proven on a non-prod node (thin wrappers over existing `Validate()`/`DefaultForMode()`; resolve the cobra-host coexistence first).
+- **`seid config …` CLI (urfave/cli v3)** → once the seam is proven on a non-prod node. Thin wrappers over existing `Validate()`/`DefaultForMode()`; must ship a deterministic exit-code scheme (0 = clean/no-op; nonzero = validation-fail/migration-aborted; distinct code for refuse-on-newer-schema) so initContainer/Job orchestration can branch on it.
 - **Unified `sei.toml` on disk (Phase 3)** → after the two-file round-trip is trusted on ≥3 real node fixtures for a release cycle.
 - **Migration functions** → when the first schema-breaking change forces `CurrentVersion` to 2.
 - **K8s render-at-init + secret-field enforcement** → before any environment uses ConfigMap-driven delivery (until then, secret deny-list is documented, not enforced).
@@ -94,4 +100,4 @@ Out of core scope; captured so the analysis isn't lost.
 
 - The deployed `SeiNode` CRD union is `validator / fullNode / archive / replayer` — it has **no `seed`** and uses **`fullNode`** (not `full`). The prototype ships `validator / full / seed / archive`.
 - `seed` produces operator-CLI defaults only and has no CRD target; `replayer` (mandatory snapshot + peers) is first-class in the fleet but absent from the prototype.
-- Aligning the enum — add `replayer`, reconcile `seed`, settle `full` vs `fullNode` casing — is a public-contract change that keys `generate --mode` and the migration registry, so it is a one-way door. **Deferred per owner decision; un-defer when generating `replayer` nodes is required.**
+- Aligning the enum — add `replayer`, reconcile `seed`, settle `full` vs `fullNode` casing — is a one-way door only on the **`generate --mode` CLI surface** (the public contract). The migration registry keys on integer version, not mode strings, so a `v1→v2` migration function can rewrite `cfg.Mode` in-place and absorb the rename cleanly. **Deferred per owner decision; un-defer when generating `replayer` nodes is required.**

--- a/docs/config-manager/DESIGN.md
+++ b/docs/config-manager/DESIGN.md
@@ -1,17 +1,17 @@
 # Configuration manager — design
 
-> The deliverable in *this* PR is this design only. Implementation lands as separate PRs in three repos (sei-config / sei-chain / seictl), sketched here so reviewers can sanity-check the shape. Phase vocabulary is from [CLAUDE.md](../../CLAUDE.md): Phase 2 = today's two-file layout; Phase 3 = unified `sei.toml`.
+> The deliverable in *this* PR is this design only. Implementation lands as separate PRs (sei-config + sei-chain), sketched here so reviewers can sanity-check the shape. Phase vocabulary is from [CLAUDE.md](../../CLAUDE.md): Phase 2 = today's two-file layout; Phase 3 = unified `sei.toml`.
 
 ## Background
 
-A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos SDK + Sei custom sections: `state-commit`, `state-store`, `evm`, `giga_executor`, `wasm`, `admin_server`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper. It loads in `seid`'s `PersistentPreRunE` (`cmd/seid/cmd/root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs` in the vendored `sei-cosmos` fork).
+A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos SDK + Sei custom sections: `evm`, `state-store`, `giga_executor`, `wasm`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper. It loads in `seid`'s `PersistentPreRunE` (`root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs`, in the vendored `sei-cosmos` fork).
 
 The **sei-config library already exists and is the asset**: unified `SeiConfig`, `DefaultForMode()`, `Validate()`, a reflection registry mapping dotted keys → `SEI_*` env vars → destination file, `SEI_*`/`SEID_*` resolution, an empty versioned `MigrationRegistry` (`CurrentVersion = 1`), and atomic round-trip IO onto the two legacy files. **Nothing calls it yet.** The risk is entirely at the seam into `seid` and in round-trip fidelity against *real* operator config files — not in the library internals.
 
 ## Goals
 
 - An **env-var-gated** path in `seid` that resolves config through the sei-config library instead of the legacy loader. Default off; legacy path byte-for-byte unchanged.
-- A management CLI (`seictl`) exposing the library's existing capabilities: `doctor` (validate), `generate --mode` (node-type defaults), `migrate` (schema versioning).
+- An in-binary `seid config …` command group (urfave/cli v3) exposing the library's existing capabilities: `doctor` (validate), `generate --mode` (node-type defaults), `migrate` (schema versioning).
 - A versioning contract that lets a config be migrated safely across `seid` releases.
 - Keep all changes **inside the sei-chain repo proper** — touch zero lines of the `sei-cosmos` fork.
 
@@ -19,20 +19,23 @@ The **sei-config library already exists and is the asset**: unified `SeiConfig`,
 
 - One physical config file (Phase 3). Phase 2 maps the unified config across the existing two files; `sei.toml`-on-disk is deferred.
 - Owning `seid init`, `client.toml`, secret material, or hot-reload.
-- Weaving a CLI framework into `seid` (see decision below).
-- Writing actual migration functions — `CurrentVersion` is 1; there is nothing to migrate yet.
+- Folding sei-config into the sei-chain tree *now* — it stays an imported dependency (see *Future: fold-in*).
+- Writing actual migration functions — `CurrentVersion` is 1; nothing to migrate yet.
+- Mode extensions (`replayer`, `seed`/CRD alignment) — see [Appendix A](#appendix-a--modes-beyond-the-core).
 
-## ⚠️ Decision: urfave/cli v3 lives in `seictl`, not in `seid`
+## ⚠️ Decision: the CLI surface is an in-binary `seid config …` group (urfave/cli v3)
 
-The vision names urfave/cli v3 as the single-file-config UX. But `seid` is cobra-rooted, and two arg-parsers in one binary collide (two help systems, two `os.Args` consumers) for no user benefit. All three consulted specialists landed here independently. **Resolution:** `seid` gets only the runtime *seam* (pure cobra/library call, no CLI framework); the urfave/cli v3 surface ships as **`seictl`**, a separate binary importing the library — a consumer CLAUDE.md already names. This honors the urfave/cli v3 requirement without the collision. Reviewers should confirm this split first.
+The management UX (`doctor`/`generate`/`migrate`/`show`) ships **inside the `seid` binary** as a `seid config …` command group on urfave/cli v3 — not a separate `seictl`. One binary, one home for config logic, consistent with seid eventually owning its own config. **Open tension (for cross-review):** seid's root is cobra, so a single cobra command must delegate its args to a urfave `cli.Command`; that boundary (help, flag parsing, completion) is what the next review must validate — earlier review flagged cobra↔urfave coexistence as a real cost, and choosing urfave in-binary accepts it deliberately. The runtime *seam* (below) is unaffected: pure library calls, no CLI framework.
 
-## Architecture — three pieces, three repos
+## Architecture — two repos
 
 | Piece | Repo | Role |
 |---|---|---|
-| `seiconfig` library | sei-config | The brain — exists today. Resolution, modes, validate, migrate, legacy IO. |
-| Env-gated seam | sei-chain | `PersistentPreRunE` hook that routes config through the library when gated on. |
-| `seictl` (urfave/cli v3) | seictl | Operator/CI surface: `config doctor \| generate \| migrate \| show`. |
+| `seiconfig` library | sei-config | The brain — exists today. Resolution, modes, validate, migrate, legacy IO. **Imported as a dependency** by sei-chain. |
+| Env-gated seam | sei-chain | `PersistentPreRunE` hook routing config through the library when gated on. |
+| `seid config …` CLI | sei-chain | In-binary operator/CI surface (urfave/cli v3): `doctor \| generate \| migrate \| show`. |
+
+**Future: fold-in.** There's a real chance sei-config later collapses into the sei-chain tree so seid owns its own config outright. Because the dependency arrow points only sei-chain → sei-config (never back), that's a `git mv` + import-path change — **the seam contract is unchanged**. Reversible; the only discipline is keeping sei-config a clean leaf (minimal deps, no seid coupling), which CLAUDE.md already mandates.
 
 **The seam contract (load-bearing).** Inject at `root.go:101-103`, after the existing `init` skip (`:97`). When gated on, the new path must produce exactly what the legacy path does, because `start.go`/`newApp` read config through **two** channels off the server context:
 
@@ -45,15 +48,15 @@ So the gated path **materializes the two legacy files via the library, then hand
 
 `SEI_CONFIG_MANAGER`, **value-based** (not presence): `v2` → new path; unset/`legacy` → legacy (default); any other value → hard startup error (never silent fallback). Read with raw `os.Getenv` at the top of `PersistentPreRunE`, before Viper init — it is not itself a config field. Value-based keeps it a clean two-way door: flip to `legacy`, restart, zero residue.
 
-**`SEI_` prefix collision (must-fix).** `seid` already claims `SEI_` via `client.Context.WithViper("SEI")`; the library also uses `SEI_`. With the gate on, both resolve the same env vars — fine *only if they agree on destination*. The implementation PR must ship a **collision audit**: diff Viper's `AutomaticEnv` `SEI_*` keys against the library's `buildEnvMap` output; any disagreement is a release blocker. Precedence ladder (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` wins over deprecated `SEID_*` with a stderr warning.
+**`SEI_` prefix collision (must-fix).** `seid` already claims `SEI_` via `WithViper("SEI")`; the library uses `SEI_` too. Gated on, both resolve the same env vars — fine *only if they agree on destination*. The implementation PR must ship a **collision audit** (diff Viper's `AutomaticEnv` `SEI_*` keys against the library's `buildEnvMap`; any disagreement blocks release). Precedence (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` beats deprecated `SEID_*` (stderr warning).
 
 ## Versioning & migration
 
-A `schema_version` integer owned by the registry, **decoupled from the seid release version** (bumps only on config *shape* change; releases→schema in a static code table). `doctor` compares it to `seiconfig.CurrentVersion`: newer → **refuse to start**; older → report "migration available." **No auto-migrate on boot** — migration is explicit (`seictl config migrate`), dry-run by default, writes timestamped `.bak` before `--write`, no-ops when current. Auto-migrate plus the registry's no-downgrade rule is a per-pod one-way door that breaks rollback. The MVP seam only **stamps `schema_version` on write**; the `doctor`/refuse-on-newer/migrate behaviors above ride with the (deferred) CLI and the first real migration — there is nothing to migrate while `CurrentVersion` is 1.
+A `schema_version` integer owned by the registry, **decoupled from the seid release version** (bumps only on config *shape* change; releases→schema in a static code table). `doctor` compares it to `seiconfig.CurrentVersion`: newer → **refuse to start**; older → report "migration available." **No auto-migrate on boot** — migration is explicit (`seid config migrate`), dry-run by default, writes timestamped `.bak` before `--write`, no-ops when current. Auto-migrate + no-downgrade is a per-pod one-way door that breaks rollback. The MVP seam only **stamps `schema_version` on write**; the `doctor`/refuse-on-newer/migrate behaviors ride with the (deferred) CLI and the first real migration — nothing to migrate while `CurrentVersion` is 1.
 
 ## Modes
 
-Keep the prototype's four — `validator / full / seed / archive` — unchanged. Modes own **static, role-shaped defaults at generate time only**: which indexers/APIs/EVM/state-store are on, pruning posture, listen addresses. Modes own **nothing at runtime** (no enforcement, no drift loop — that's the controller's job). Per-node identity (`moniker`, `p2p.persistent_peers`, `p2p.external_address`, keys) comes from operator/controller overrides and **never** from a mode default. Recommended guard test: `Validate()` fails CI if an identity-bearing key appears in any mode's static defaults. `DefaultForMode(mode)` stays a pure function of the mode enum. Note: `seed` produces operator-CLI defaults only — it has no `SeiNode` CRD target until enum alignment, so the four modes are not all controller-round-trippable.
+Keep the prototype's four — `validator / full / seed / archive` — unchanged. Modes own **static, role-shaped defaults at generate time only**: which indexers/APIs/EVM/state-store are on, pruning posture, listen addresses. Modes own **nothing at runtime** (no enforcement, no drift loop — that's the controller's job). Per-node identity (`moniker`, `p2p.persistent_peers`, `p2p.external_address`, keys) comes from operator/controller overrides, **never** a mode default. Recommended guard test: `Validate()` fails CI if an identity-bearing key appears in any mode's static defaults. `DefaultForMode(mode)` stays a pure function of the mode enum. (Taxonomy nuance — `replayer`, `seed`, `full` vs `fullNode` — out of core scope; see [Appendix A](#appendix-a--modes-beyond-the-core).)
 
 ## MVP — the first implementation PR
 
@@ -63,23 +66,32 @@ In: the gate + seam (both channels populated); the collision audit; a **fidelity
 
 ## Deferred (with un-defer trigger)
 
-- **`seictl` CLI + urfave/cli v3** → once the seam is proven on a non-prod node (thin wrappers over existing `Validate()`/`DefaultForMode()`).
+- **`seid config …` CLI (urfave/cli v3)** → once the seam is proven on a non-prod node (thin wrappers over existing `Validate()`/`DefaultForMode()`; resolve the cobra-host coexistence first).
 - **Unified `sei.toml` on disk (Phase 3)** → after the two-file round-trip is trusted on ≥3 real node fixtures for a release cycle.
 - **Migration functions** → when the first schema-breaking change forces `CurrentVersion` to 2.
 - **K8s render-at-init + secret-field enforcement** → before any environment uses ConfigMap-driven delivery (until then, secret deny-list is documented, not enforced).
-- **`replayer` mode / dropping `seed`** → the deployed `SeiNode` CRD union is `validator/fullNode/archive/replayer` (no `seed`); enum alignment is a public-contract change deferred per owner decision.
+- **Mode/CRD alignment** ([Appendix A](#appendix-a--modes-beyond-the-core)) → when generating `replayer` nodes is required.
 - **sei-k8s-controller / structured JSON output** → second consumer; library already exposes `ConfigIntent`.
 
 ## Open questions
 
 1. Replicate `SEI_LOG_LEVEL` extrapolation (`util.go:187-217`) in the gated path, or accept a documented behavior delta?
 2. Where does the on-disk `schema_version` live so a legacy-only checkout can be detected — managed header in `app.toml`, or only in the future `sei.toml`?
-3. Final `seictl` command naming/casing (`full` vs CRD's `fullNode`).
+3. Final `seid config …` command naming and flags.
 
 ## Cross-repo coordination
 
-- **This PR (sei-config):** the design. The library contract (version field, any new facade) follows as a sei-config PR.
-- **Follow-up sei-chain PR:** the env-gated seam + fidelity test + collision audit.
-- **Follow-up seictl PR:** the urfave/cli v3 management CLI.
+- **This PR (sei-config):** the design. Any library contract change (e.g. version stamping) follows as a sei-config PR, tagged for sei-chain to pin.
+- **Follow-up sei-chain PR(s):** the env-gated seam + fidelity test + collision audit; then the in-binary `seid config …` CLI.
 
-The seam PR must not merge until the collision audit passes and the fidelity test is green. `seictl` can follow independently once the library version it pins is tagged.
+The seam PR must not merge until the collision audit passes and the fidelity test is green. The `seid config …` CLI can follow once the pinned sei-config version is tagged.
+
+---
+
+## Appendix A — modes beyond the core
+
+Out of core scope; captured so the analysis isn't lost.
+
+- The deployed `SeiNode` CRD union is `validator / fullNode / archive / replayer` — it has **no `seed`** and uses **`fullNode`** (not `full`). The prototype ships `validator / full / seed / archive`.
+- `seed` produces operator-CLI defaults only and has no CRD target; `replayer` (mandatory snapshot + peers) is first-class in the fleet but absent from the prototype.
+- Aligning the enum — add `replayer`, reconcile `seed`, settle `full` vs `fullNode` casing — is a public-contract change that keys `generate --mode` and the migration registry, so it is a one-way door. **Deferred per owner decision; un-defer when generating `replayer` nodes is required.**

--- a/docs/config-manager/DESIGN.md
+++ b/docs/config-manager/DESIGN.md
@@ -1,0 +1,85 @@
+# Configuration manager — design
+
+> The deliverable in *this* PR is this design only. Implementation lands as separate PRs in three repos (sei-config / sei-chain / seictl), sketched here so reviewers can sanity-check the shape. Phase vocabulary is from [CLAUDE.md](../../CLAUDE.md): Phase 2 = today's two-file layout; Phase 3 = unified `sei.toml`.
+
+## Background
+
+A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos SDK + Sei custom sections: `state-commit`, `state-store`, `evm`, `giga_executor`, `wasm`, `admin_server`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper. It loads in `seid`'s `PersistentPreRunE` (`cmd/seid/cmd/root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs` in the vendored `sei-cosmos` fork).
+
+The **sei-config library already exists and is the asset**: unified `SeiConfig`, `DefaultForMode()`, `Validate()`, a reflection registry mapping dotted keys → `SEI_*` env vars → destination file, `SEI_*`/`SEID_*` resolution, an empty versioned `MigrationRegistry` (`CurrentVersion = 1`), and atomic round-trip IO onto the two legacy files. **Nothing calls it yet.** The risk is entirely at the seam into `seid` and in round-trip fidelity against *real* operator config files — not in the library internals.
+
+## Goals
+
+- An **env-var-gated** path in `seid` that resolves config through the sei-config library instead of the legacy loader. Default off; legacy path byte-for-byte unchanged.
+- A management CLI (`seictl`) exposing the library's existing capabilities: `doctor` (validate), `generate --mode` (node-type defaults), `migrate` (schema versioning).
+- A versioning contract that lets a config be migrated safely across `seid` releases.
+- Keep all changes **inside the sei-chain repo proper** — touch zero lines of the `sei-cosmos` fork.
+
+## Non-goals
+
+- One physical config file (Phase 3). Phase 2 maps the unified config across the existing two files; `sei.toml`-on-disk is deferred.
+- Owning `seid init`, `client.toml`, secret material, or hot-reload.
+- Weaving a CLI framework into `seid` (see decision below).
+- Writing actual migration functions — `CurrentVersion` is 1; there is nothing to migrate yet.
+
+## ⚠️ Decision: urfave/cli v3 lives in `seictl`, not in `seid`
+
+The vision names urfave/cli v3 as the single-file-config UX. But `seid` is cobra-rooted, and two arg-parsers in one binary collide (two help systems, two `os.Args` consumers) for no user benefit. All three consulted specialists landed here independently. **Resolution:** `seid` gets only the runtime *seam* (pure cobra/library call, no CLI framework); the urfave/cli v3 surface ships as **`seictl`**, a separate binary importing the library — a consumer CLAUDE.md already names. This honors the urfave/cli v3 requirement without the collision. Reviewers should confirm this split first.
+
+## Architecture — three pieces, three repos
+
+| Piece | Repo | Role |
+|---|---|---|
+| `seiconfig` library | sei-config | The brain — exists today. Resolution, modes, validate, migrate, legacy IO. |
+| Env-gated seam | sei-chain | `PersistentPreRunE` hook that routes config through the library when gated on. |
+| `seictl` (urfave/cli v3) | seictl | Operator/CI surface: `config doctor \| generate \| migrate \| show`. |
+
+**The seam contract (load-bearing).** Inject at `root.go:101-103`, after the existing `init` skip (`:97`). When gated on, the new path must produce exactly what the legacy path does, because `start.go`/`newApp` read config through **two** channels off the server context:
+
+1. `serverCtx.Config` — a fully-populated, `SetRoot`-applied, `ValidateBasic`-passing `*tmcfg.Config`.
+2. `serverCtx.Viper` — used as `AppOptions`; every Sei section is read via `appOpts.Get("evm.http_port")`-style dotted lookups.
+
+So the gated path **materializes the two legacy files via the library, then hands off to the same Viper read+merge tail** (`sei-cosmos/server/util.go:162-219, 317-323`) and calls `bindFlags` to preserve flag>env>file precedence. **It must not feed `app.New` from the in-memory `SeiConfig` struct** — that silently drops keys the struct doesn't model. Failure modes to test: Viper left unpopulated (silent zero-value misconfig), flag-precedence inversion, `init`-vs-`start` divergence (gated path must tolerate files it didn't author). `client.toml` is handled before the gate and stays out of scope.
+
+## Env-var gate contract
+
+`SEI_CONFIG_MANAGER`, **value-based** (not presence): `v2` → new path; unset/`legacy` → legacy (default); any other value → hard startup error (never silent fallback). Read with raw `os.Getenv` at the top of `PersistentPreRunE`, before Viper init — it is not itself a config field. Value-based keeps it a clean two-way door: flip to `legacy`, restart, zero residue.
+
+**`SEI_` prefix collision (must-fix).** `seid` already claims `SEI_` via `client.Context.WithViper("SEI")`; the library also uses `SEI_`. With the gate on, both resolve the same env vars — fine *only if they agree on destination*. The implementation PR must ship a **collision audit**: diff Viper's `AutomaticEnv` `SEI_*` keys against the library's `buildEnvMap` output; any disagreement is a release blocker. Precedence ladder (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` wins over deprecated `SEID_*` with a stderr warning.
+
+## Versioning & migration
+
+A `schema_version` integer owned by the registry, **decoupled from the seid release version** (bumps only on config *shape* change; releases→schema in a static code table). `doctor` compares it to `seiconfig.CurrentVersion`: newer → **refuse to start**; older → report "migration available." **No auto-migrate on boot** — migration is explicit (`seictl config migrate`), dry-run by default, writes timestamped `.bak` before `--write`, no-ops when current. Auto-migrate plus the registry's no-downgrade rule is a per-pod one-way door that breaks rollback. The MVP seam only **stamps `schema_version` on write**; the `doctor`/refuse-on-newer/migrate behaviors above ride with the (deferred) CLI and the first real migration — there is nothing to migrate while `CurrentVersion` is 1.
+
+## Modes
+
+Keep the prototype's four — `validator / full / seed / archive` — unchanged. Modes own **static, role-shaped defaults at generate time only**: which indexers/APIs/EVM/state-store are on, pruning posture, listen addresses. Modes own **nothing at runtime** (no enforcement, no drift loop — that's the controller's job). Per-node identity (`moniker`, `p2p.persistent_peers`, `p2p.external_address`, keys) comes from operator/controller overrides and **never** from a mode default. Recommended guard test: `Validate()` fails CI if an identity-bearing key appears in any mode's static defaults. `DefaultForMode(mode)` stays a pure function of the mode enum. Note: `seed` produces operator-CLI defaults only — it has no `SeiNode` CRD target until enum alignment, so the four modes are not all controller-round-trippable.
+
+## MVP — the first implementation PR
+
+**One sentence of value:** *a real `seid` home directory resolves through the library and produces a node that behaves identically to the legacy path, behind an off-by-default env flag.* If that holds, everything downstream (CLI, modes, migration) is de-risked.
+
+In: the gate + seam (both channels populated); the collision audit; a **fidelity test against a sanitized real `config.toml`/`app.toml`** asserting every operator-set key `seid` consumes survives read→write (this is the non-negotiable safety property, not synthetic-default round-trips); a documented `KNOWN_UNMAPPED_FIELDS` list (e.g. `ChainID` lives in genesis.json). Done = legacy path provably unchanged with flag unset; gated path starts identically and refuses-to-start on `Validate` errors; `make ci` green.
+
+## Deferred (with un-defer trigger)
+
+- **`seictl` CLI + urfave/cli v3** → once the seam is proven on a non-prod node (thin wrappers over existing `Validate()`/`DefaultForMode()`).
+- **Unified `sei.toml` on disk (Phase 3)** → after the two-file round-trip is trusted on ≥3 real node fixtures for a release cycle.
+- **Migration functions** → when the first schema-breaking change forces `CurrentVersion` to 2.
+- **K8s render-at-init + secret-field enforcement** → before any environment uses ConfigMap-driven delivery (until then, secret deny-list is documented, not enforced).
+- **`replayer` mode / dropping `seed`** → the deployed `SeiNode` CRD union is `validator/fullNode/archive/replayer` (no `seed`); enum alignment is a public-contract change deferred per owner decision.
+- **sei-k8s-controller / structured JSON output** → second consumer; library already exposes `ConfigIntent`.
+
+## Open questions
+
+1. Replicate `SEI_LOG_LEVEL` extrapolation (`util.go:187-217`) in the gated path, or accept a documented behavior delta?
+2. Where does the on-disk `schema_version` live so a legacy-only checkout can be detected — managed header in `app.toml`, or only in the future `sei.toml`?
+3. Final `seictl` command naming/casing (`full` vs CRD's `fullNode`).
+
+## Cross-repo coordination
+
+- **This PR (sei-config):** the design. The library contract (version field, any new facade) follows as a sei-config PR.
+- **Follow-up sei-chain PR:** the env-gated seam + fidelity test + collision audit.
+- **Follow-up seictl PR:** the urfave/cli v3 management CLI.
+
+The seam PR must not merge until the collision audit passes and the fidelity test is green. `seictl` can follow independently once the library version it pins is tagged.

--- a/docs/config-manager/DESIGN.md
+++ b/docs/config-manager/DESIGN.md
@@ -4,12 +4,12 @@
 
 ## Background
 
-A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos + Sei sections: `evm`, `state-store`, `giga_executor`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper — loaded in `PersistentPreRunE` (`root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs`, in the vendored `sei-cosmos` fork). The **sei-config library already exists and is the asset** (unified `SeiConfig`, `DefaultForMode()`, `Validate()`, a key→env→file registry, `SEI_*`/`SEID_*` resolution, an empty `MigrationRegistry` at `CurrentVersion=1`, atomic two-file IO) — **but nothing calls it yet.** The risk is entirely at the seam into `seid` and round-trip fidelity against *real* config files, not in the library.
+A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos + Sei sections: `evm`, `state-store`, `giga_executor`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper — loaded in `PersistentPreRunE` (`root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs`, in the vendored `sei-cosmos` fork). The **sei-config library already exists and is the asset** (unified `SeiConfig`, `DefaultForMode()`, `Validate()`, a key→env→file registry, `SEI_*`/`SEID_*` resolution, an empty `MigrationRegistry` at `CurrentVersion=1`, atomic two-file IO) — **but nothing calls it yet.** This project makes `seid` a **consumer** of that library: a second, *experimental* configuration manager that `seid` selects over the legacy loader when an experimental env var (or config setting) says so. The risk is entirely at that selection seam and in round-trip fidelity against *real* config files — not in the library.
 
 ## Goals
 
-- An **env-var-gated** path in `seid` resolving config through the library instead of the legacy loader; default off, legacy path byte-for-byte unchanged.
-- An in-binary `seid config …` group (`doctor` / `generate --mode` / `migrate`) over the library's existing capabilities.
+- `seid` **selects** its configuration manager at startup via an experimental env var/config — legacy loader (default) vs the sei-config-backed manager; legacy path byte-for-byte unchanged.
+- The sei-config-backed manager exposes the library's capabilities in-binary (`doctor` / `generate --mode` / `migrate`).
 - A versioning contract for migrating config safely across `seid` releases.
 - All changes **inside the sei-chain repo** — zero lines of the `sei-cosmos` fork.
 
@@ -17,25 +17,25 @@ A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (
 
 Phase 3 (one physical `sei.toml`); owning `seid init`, `client.toml`, secrets, or hot-reload; writing migration functions (`CurrentVersion=1`, nothing to migrate); folding sei-config into sei-chain *now* (stays a dependency — see *Future: fold-in*); mode extensions (`replayer`, `seed`/CRD — [Appendix A](#appendix-a--modes-beyond-the-core)).
 
-## ⚠️ Decision: in-binary `seid config …` group on urfave/cli v3
+## ⚠️ Decision: the experimental manager lives in `seid`, driven by urfave/cli v3
 
-The management UX ships **inside the `seid` binary** as a `seid config …` group on urfave/cli v3 — not a separate `seictl`. One binary, one home for config logic, and CLI-vs-node version skew is impossible (the tool *is* the node binary). The one seam-relevant constraint: **`config` must skip `PersistentPreRunE`** — that hook runs for every subcommand, so without a guard `seid config …` would trigger the legacy interception (and under `SEI_CONFIG_MANAGER=v2`, the gated seam *recursively*), mutating files just to inspect them. Extend the `init` skip at `root.go:97` to also short-circuit `config`. Delegation pattern + accepted costs: [Appendix B](#appendix-b--seid-config-cobraurfave-integration).
+The sei-config-backed manager — including its `config …` surface (`doctor`/`generate`/`migrate`/`show`) — runs **inside the `seid` binary** on urfave/cli v3. There is no separate config tool: `seid` is the single consumer and single binary, so CLI-vs-node version skew is impossible (the tool *is* the node binary). The one seam-relevant constraint: **`config` must skip `PersistentPreRunE`** — that hook runs for every subcommand, so without a guard `seid config …` would trigger the legacy interception (and under `SEI_CONFIG_MANAGER=v2`, the gated seam *recursively*), mutating files just to inspect them. Extend the `init` skip at `root.go:97` to also short-circuit `config`. Delegation pattern + accepted costs: [Appendix B](#appendix-b--seid-config-cobraurfave-integration).
 
 ## Architecture — two repos
 
 | Piece | Repo | Role |
 |---|---|---|
-| `seiconfig` library | sei-config | The brain (exists). Resolution, modes, validate, migrate, legacy IO. **Imported by** sei-chain. |
-| Env-gated seam | sei-chain | `PersistentPreRunE` hook routing config through the library when gated on. |
-| `seid config …` CLI | sei-chain | In-binary surface: `doctor \| generate \| migrate \| show`. |
+| `seiconfig` library | sei-config | The brain (exists). Resolution, modes, validate, migrate, legacy IO. **Consumed by** `seid`. |
+| Selection seam | sei-chain | `PersistentPreRunE` reads the experimental flag; routes to legacy or the sei-config-backed manager. |
+| Experimental manager | sei-chain | In-binary, urfave/cli v3: resolves config + `config …` verbs (`doctor \| generate \| migrate \| show`). |
 
-**Future: fold-in.** sei-config may later collapse into the sei-chain tree so seid owns its own config. The dependency arrow is one-way (sei-chain → sei-config), so that's a `git mv` + import change — **seam unchanged**. Reversible; the only discipline is keeping sei-config a clean leaf, which CLAUDE.md already mandates.
+**Future (deferred).** Two consolidations may follow, both reversible and out of scope now: (1) **fold-in** — sei-config collapses into the sei-chain tree so `seid` owns its own config; the dependency arrow is one-way (sei-chain → sei-config), so it's a `git mv` + import change with the seam unchanged. (2) **controller consolidation** — `sei-k8s-controller` stops calling the library directly and drives config through `seid` itself, making `seid` the single config authority. Both deferred; the only discipline now is keeping sei-config a clean leaf, which CLAUDE.md already mandates.
 
 **The seam contract (load-bearing).** Inject at `root.go:101-103`, after the `init` skip. When gated on, the new path must produce exactly what the legacy path does, because `start.go`/`newApp` read config through **two** channels: `serverCtx.Config` (a fully-populated, `SetRoot`/`ValidateBasic`-passing `*tmcfg.Config`) **and** `serverCtx.Viper` (used as `AppOptions` — every Sei section read via `appOpts.Get("evm.http_port")` dotted lookups). So the gated path **materializes the two legacy files, then re-enters the same Viper read+merge tail** (`sei-cosmos/server/util.go:162-219, 317-323`) and calls `bindFlags` for flag>env>file precedence. **It must not feed `app.New` from the in-memory struct** — that silently drops unmodeled keys. Test for: Viper left unpopulated, flag-precedence inversion, `init`-vs-`start` divergence. `client.toml` is handled before the gate, out of scope.
 
 ## Env-var gate contract
 
-`SEI_CONFIG_MANAGER`, **value-based**: `v2` → new path; unset/`legacy` → legacy (default); anything else → hard startup error (never silent fallback). Read via raw `os.Getenv` atop `PersistentPreRunE`; keeps a clean two-way door. **`SEI_` collision (must-fix):** `seid` already claims `SEI_` via `WithViper("SEI")` and the library uses `SEI_` too — gated on, both resolve the same env vars, fine *only if they agree on destination*. The implementation PR ships a **collision audit** (diff Viper `AutomaticEnv` `SEI_*` keys vs the library's `buildEnvMap`; any disagreement blocks release). Precedence (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` beats deprecated `SEID_*` (stderr warning).
+`SEI_CONFIG_MANAGER` (experimental, opt-in), **value-based**: `v2` → the sei-config-backed manager; unset/`legacy` → legacy (default); anything else → hard startup error (never silent fallback). Read via raw `os.Getenv` atop `PersistentPreRunE`; keeps a clean two-way door. **`SEI_` collision (must-fix):** `seid` already claims `SEI_` via `WithViper("SEI")` and the library uses `SEI_` too — gated on, both resolve the same env vars, fine *only if they agree on destination*. The implementation PR ships a **collision audit** (diff Viper `AutomaticEnv` `SEI_*` keys vs the library's `buildEnvMap`; any disagreement blocks release). Precedence (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` beats deprecated `SEID_*` (stderr warning).
 
 ## Versioning & migration
 
@@ -56,7 +56,7 @@ Keep the prototype's four — `validator / full / seed / archive`. Modes own **s
 - **Migration functions** → when the first breaking change forces `CurrentVersion`→2.
 - **K8s render-at-init + secret-field enforcement** → before any env uses ConfigMap delivery (until then, secret deny-list documented, not enforced).
 - **Mode/CRD alignment** ([Appendix A](#appendix-a--modes-beyond-the-core)) → when generating `replayer` nodes is required.
-- **sei-k8s-controller / JSON output** → second consumer; library already exposes `ConfigIntent`.
+- **Controller consolidation onto `seid`** → `sei-k8s-controller` drives config through `seid` instead of calling the library directly (see *Future*); until then the library exposes `ConfigIntent` for direct use.
 
 ## Open questions
 

--- a/docs/config-manager/DESIGN.md
+++ b/docs/config-manager/DESIGN.md
@@ -1,96 +1,72 @@
 # Configuration manager — design
 
-> The deliverable in *this* PR is this design only. Implementation lands as separate PRs (sei-config + sei-chain), sketched here so reviewers can sanity-check the shape. Phase vocabulary is from [CLAUDE.md](../../CLAUDE.md): Phase 2 = today's two-file layout; Phase 3 = unified `sei.toml`.
+> This PR ships the design only; implementation lands as separate PRs (sei-config + sei-chain). Phase vocabulary from [CLAUDE.md](../../CLAUDE.md): Phase 2 = today's two-file layout; Phase 3 = unified `sei.toml`.
 
 ## Background
 
-A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos SDK + Sei custom sections: `evm`, `state-store`, `giga_executor`, `wasm`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper. It loads in `seid`'s `PersistentPreRunE` (`root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs`, in the vendored `sei-cosmos` fork).
-
-The **sei-config library already exists and is the asset**: unified `SeiConfig`, `DefaultForMode()`, `Validate()`, a reflection registry mapping dotted keys → `SEI_*` env vars → destination file, `SEI_*`/`SEID_*` resolution, an empty versioned `MigrationRegistry` (`CurrentVersion = 1`), and atomic round-trip IO onto the two legacy files. **Nothing calls it yet.** The risk is entirely at the seam into `seid` and in round-trip fidelity against *real* operator config files — not in the library internals.
+A `seid` node's config is spread across `config.toml` (Tendermint), `app.toml` (Cosmos + Sei sections: `evm`, `state-store`, `giga_executor`, …), `client.toml`, cobra flags, and `SEID_*`/`SEI_*` env vars resolved by Viper — loaded in `PersistentPreRunE` (`root.go:79-104` → `InterceptConfigsPreRunHandler` → `interceptConfigs`, in the vendored `sei-cosmos` fork). The **sei-config library already exists and is the asset** (unified `SeiConfig`, `DefaultForMode()`, `Validate()`, a key→env→file registry, `SEI_*`/`SEID_*` resolution, an empty `MigrationRegistry` at `CurrentVersion=1`, atomic two-file IO) — **but nothing calls it yet.** The risk is entirely at the seam into `seid` and round-trip fidelity against *real* config files, not in the library.
 
 ## Goals
 
-- An **env-var-gated** path in `seid` that resolves config through the sei-config library instead of the legacy loader. Default off; legacy path byte-for-byte unchanged.
-- An in-binary `seid config …` command group exposing the library's existing capabilities: `doctor` (validate), `generate --mode` (node-type defaults), `migrate` (schema versioning). *(Framework + cobra coexistence: see Decision.)*
-- A versioning contract that lets a config be migrated safely across `seid` releases.
-- Keep all changes **inside the sei-chain repo proper** — touch zero lines of the `sei-cosmos` fork.
+- An **env-var-gated** path in `seid` resolving config through the library instead of the legacy loader; default off, legacy path byte-for-byte unchanged.
+- An in-binary `seid config …` group (`doctor` / `generate --mode` / `migrate`) over the library's existing capabilities.
+- A versioning contract for migrating config safely across `seid` releases.
+- All changes **inside the sei-chain repo** — zero lines of the `sei-cosmos` fork.
 
 ## Non-goals
 
-- One physical config file (Phase 3). Phase 2 maps the unified config across the existing two files; `sei.toml`-on-disk is deferred.
-- Owning `seid init`, `client.toml`, secret material, or hot-reload.
-- Folding sei-config into the sei-chain tree *now* — it stays an imported dependency (see *Future: fold-in*).
-- Writing actual migration functions — `CurrentVersion` is 1; nothing to migrate yet.
-- Mode extensions (`replayer`, `seed`/CRD alignment) — see [Appendix A](#appendix-a--modes-beyond-the-core).
+Phase 3 (one physical `sei.toml`); owning `seid init`, `client.toml`, secrets, or hot-reload; writing migration functions (`CurrentVersion=1`, nothing to migrate); folding sei-config into sei-chain *now* (stays a dependency — see *Future: fold-in*); mode extensions (`replayer`, `seed`/CRD — [Appendix A](#appendix-a--modes-beyond-the-core)).
 
-## ⚠️ Decision: the CLI surface is an in-binary `seid config …` group (urfave/cli v3)
+## ⚠️ Decision: in-binary `seid config …` group on urfave/cli v3
 
-The management UX (`doctor`/`generate`/`migrate`/`show`) ships **inside the `seid` binary** as a `seid config …` command group on urfave/cli v3 — not a separate `seictl`. One binary, one home for config logic, consistent with seid eventually owning its own config; it also kills CLI-vs-node version skew (the migration tool *is* the node binary). Cross-review settled the cobra↔urfave coexistence:
-
-- **`config` skips the persistent prerun.** `PersistentPreRunE` runs for every subcommand; without a guard `seid config …` would trigger `InterceptConfigsPreRunHandler` (and under `SEI_CONFIG_MANAGER=v2`, the gated seam *recursively*) — mutating files just to inspect them. Extend the `init` skip at `root.go:97` to also short-circuit `config`.
-- **Delegation:** one `config` cobra command with `DisableFlagParsing: true` (already used at `root.go:176,200`) hands the raw arg tail to urfave; urfave owns only the `config` subtree, never global flags. Errors propagate via `RunE` to `main.go`'s `os.Exit`; urfave's exit handler is a no-op.
-- **Accepted costs:** go.mod already carries urfave/cli **v2**; v3 adds a second major version (deliberate). Completion can't introspect a `DisableFlagParsing` subtree, so `config` won't autocomplete (deferred).
-
-The runtime *seam* (below) is otherwise unaffected: pure library calls, no CLI framework.
+The management UX ships **inside the `seid` binary** as a `seid config …` group on urfave/cli v3 — not a separate `seictl`. One binary, one home for config logic, and CLI-vs-node version skew is impossible (the tool *is* the node binary). The one seam-relevant constraint: **`config` must skip `PersistentPreRunE`** — that hook runs for every subcommand, so without a guard `seid config …` would trigger the legacy interception (and under `SEI_CONFIG_MANAGER=v2`, the gated seam *recursively*), mutating files just to inspect them. Extend the `init` skip at `root.go:97` to also short-circuit `config`. Delegation pattern + accepted costs: [Appendix B](#appendix-b--seid-config-cobraurfave-integration).
 
 ## Architecture — two repos
 
 | Piece | Repo | Role |
 |---|---|---|
-| `seiconfig` library | sei-config | The brain — exists today. Resolution, modes, validate, migrate, legacy IO. **Imported as a dependency** by sei-chain. |
+| `seiconfig` library | sei-config | The brain (exists). Resolution, modes, validate, migrate, legacy IO. **Imported by** sei-chain. |
 | Env-gated seam | sei-chain | `PersistentPreRunE` hook routing config through the library when gated on. |
-| `seid config …` CLI | sei-chain | In-binary operator/CI surface: `doctor \| generate \| migrate \| show`. |
+| `seid config …` CLI | sei-chain | In-binary surface: `doctor \| generate \| migrate \| show`. |
 
-**Future: fold-in.** There's a real chance sei-config later collapses into the sei-chain tree so seid owns its own config outright. Because the dependency arrow points only sei-chain → sei-config (never back), that's a `git mv` + import-path change — **the seam contract is unchanged**. Reversible; the only discipline is keeping sei-config a clean leaf (minimal deps, no seid coupling), which CLAUDE.md already mandates.
+**Future: fold-in.** sei-config may later collapse into the sei-chain tree so seid owns its own config. The dependency arrow is one-way (sei-chain → sei-config), so that's a `git mv` + import change — **seam unchanged**. Reversible; the only discipline is keeping sei-config a clean leaf, which CLAUDE.md already mandates.
 
-**The seam contract (load-bearing).** Inject at `root.go:101-103`, after the existing `init` skip (`:97`). When gated on, the new path must produce exactly what the legacy path does, because `start.go`/`newApp` read config through **two** channels off the server context:
-
-1. `serverCtx.Config` — a fully-populated, `SetRoot`-applied, `ValidateBasic`-passing `*tmcfg.Config`.
-2. `serverCtx.Viper` — used as `AppOptions`; every Sei section is read via `appOpts.Get("evm.http_port")`-style dotted lookups.
-
-So the gated path **materializes the two legacy files via the library, then hands off to the same Viper read+merge tail** (`sei-cosmos/server/util.go:162-219, 317-323`) and calls `bindFlags` to preserve flag>env>file precedence. **It must not feed `app.New` from the in-memory `SeiConfig` struct** — that silently drops keys the struct doesn't model. Failure modes to test: Viper left unpopulated (silent zero-value misconfig), flag-precedence inversion, `init`-vs-`start` divergence (gated path must tolerate files it didn't author). `client.toml` is handled before the gate and stays out of scope.
+**The seam contract (load-bearing).** Inject at `root.go:101-103`, after the `init` skip. When gated on, the new path must produce exactly what the legacy path does, because `start.go`/`newApp` read config through **two** channels: `serverCtx.Config` (a fully-populated, `SetRoot`/`ValidateBasic`-passing `*tmcfg.Config`) **and** `serverCtx.Viper` (used as `AppOptions` — every Sei section read via `appOpts.Get("evm.http_port")` dotted lookups). So the gated path **materializes the two legacy files, then re-enters the same Viper read+merge tail** (`sei-cosmos/server/util.go:162-219, 317-323`) and calls `bindFlags` for flag>env>file precedence. **It must not feed `app.New` from the in-memory struct** — that silently drops unmodeled keys. Test for: Viper left unpopulated, flag-precedence inversion, `init`-vs-`start` divergence. `client.toml` is handled before the gate, out of scope.
 
 ## Env-var gate contract
 
-`SEI_CONFIG_MANAGER`, **value-based** (not presence): `v2` → new path; unset/`legacy` → legacy (default); any other value → hard startup error (never silent fallback). Read with raw `os.Getenv` at the top of `PersistentPreRunE`, before Viper init — it is not itself a config field. Value-based keeps it a clean two-way door: flip to `legacy`, restart, zero residue.
-
-**`SEI_` prefix collision (must-fix).** `seid` already claims `SEI_` via `WithViper("SEI")`; the library uses `SEI_` too. Gated on, both resolve the same env vars — fine *only if they agree on destination*. The implementation PR must ship a **collision audit** (diff Viper's `AutomaticEnv` `SEI_*` keys against the library's `buildEnvMap`; any disagreement blocks release). Precedence (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` beats deprecated `SEID_*` (stderr warning).
+`SEI_CONFIG_MANAGER`, **value-based**: `v2` → new path; unset/`legacy` → legacy (default); anything else → hard startup error (never silent fallback). Read via raw `os.Getenv` atop `PersistentPreRunE`; keeps a clean two-way door. **`SEI_` collision (must-fix):** `seid` already claims `SEI_` via `WithViper("SEI")` and the library uses `SEI_` too — gated on, both resolve the same env vars, fine *only if they agree on destination*. The implementation PR ships a **collision audit** (diff Viper `AutomaticEnv` `SEI_*` keys vs the library's `buildEnvMap`; any disagreement blocks release). Precedence (low→high): mode default < file < `SEI_*` env < flag; `SEI_*` beats deprecated `SEID_*` (stderr warning).
 
 ## Versioning & migration
 
-A `schema_version` integer owned by the registry, **decoupled from the seid release version** (bumps only on config *shape* change; releases→schema in a static code table). `doctor` compares it to `seiconfig.CurrentVersion`: newer → **refuse to start**; older → report "migration available." **No auto-migrate on boot** — migration is explicit (`seid config migrate`), dry-run by default, writes timestamped `.bak` before `--write`, no-ops when current. Auto-migrate + no-downgrade is a per-pod one-way door that breaks rollback. The MVP seam only **stamps `schema_version` on write**; the `doctor`/refuse-on-newer/migrate behaviors ride with the (deferred) CLI and the first real migration — nothing to migrate while `CurrentVersion` is 1.
+A `schema_version` integer owned by the registry, **decoupled from the seid release** (bumps only on shape change). `doctor` compares it to `CurrentVersion`: newer → refuse to start; older → "migration available." **No auto-migrate on boot** — migration is explicit (`seid config migrate`), dry-run by default, `.bak` before `--write`, no-ops when current; auto-migrate + no-downgrade is a per-pod one-way door that breaks rollback. The MVP seam only **stamps `schema_version` on write**; `doctor`/refuse-on-newer/migrate ride with the (deferred) CLI and the first real migration.
 
 ## Modes
 
-Keep the prototype's four — `validator / full / seed / archive` — unchanged. Modes own **static, role-shaped defaults at generate time only**: which indexers/APIs/EVM/state-store are on, pruning posture, listen addresses. Modes own **nothing at runtime** (no enforcement, no drift loop — that's the controller's job). Per-node identity (`moniker`, `p2p.persistent_peers`, `p2p.external_address`, keys) comes from operator/controller overrides, **never** a mode default. Recommended guard test: `Validate()` fails CI if an identity-bearing key appears in any mode's static defaults. `DefaultForMode(mode)` stays a pure function of the mode enum. (Taxonomy nuance — `replayer`, `seed`, `full` vs `fullNode` — out of core scope; see [Appendix A](#appendix-a--modes-beyond-the-core).)
+Keep the prototype's four — `validator / full / seed / archive`. Modes own **static, role-shaped defaults at generate time only** (which APIs/EVM/state-store are on, pruning, listen addresses); **nothing at runtime**. Per-node identity (`moniker`, `persistent_peers`, `external_address`, keys) comes from operator/controller overrides, **never** a mode default — guard test: `Validate()` fails CI if an identity key appears in any mode's defaults. `DefaultForMode(mode)` stays pure. (Taxonomy nuance → [Appendix A](#appendix-a--modes-beyond-the-core).)
 
 ## MVP — the first implementation PR
 
-**One sentence of value:** *a real `seid` home directory resolves through the library and produces a node that behaves identically to the legacy path, behind an off-by-default env flag.* If that holds, everything downstream (CLI, modes, migration) is de-risked.
+**Value:** *a real `seid` home dir resolves through the library and produces a node that behaves identically to the legacy path, behind an off-by-default flag* — which de-risks everything downstream. **In:** gate + seam (both channels); the collision audit; a **fidelity test against a sanitized real `config.toml`/`app.toml`** asserting every operator-set key `seid` consumes survives read→write (the non-negotiable safety property); a `KNOWN_UNMAPPED_FIELDS` list (e.g. `ChainID` lives in genesis.json). **Done:** legacy path provably unchanged with flag unset; gated path starts identically and refuses-to-start on `Validate` errors; `make ci` green.
 
-In: the gate + seam (both channels populated); the collision audit; a **fidelity test against a sanitized real `config.toml`/`app.toml`** asserting every operator-set key `seid` consumes survives read→write (this is the non-negotiable safety property, not synthetic-default round-trips); a documented `KNOWN_UNMAPPED_FIELDS` list (e.g. `ChainID` lives in genesis.json). Done = legacy path provably unchanged with flag unset; gated path starts identically and refuses-to-start on `Validate` errors; `make ci` green.
+## Deferred (un-defer trigger)
 
-## Deferred (with un-defer trigger)
-
-- **`seid config …` CLI (urfave/cli v3)** → once the seam is proven on a non-prod node. Thin wrappers over existing `Validate()`/`DefaultForMode()`; must ship a deterministic exit-code scheme (0 = clean/no-op; nonzero = validation-fail/migration-aborted; distinct code for refuse-on-newer-schema) so initContainer/Job orchestration can branch on it.
-- **Unified `sei.toml` on disk (Phase 3)** → after the two-file round-trip is trusted on ≥3 real node fixtures for a release cycle.
-- **Migration functions** → when the first schema-breaking change forces `CurrentVersion` to 2.
-- **K8s render-at-init + secret-field enforcement** → before any environment uses ConfigMap-driven delivery (until then, secret deny-list is documented, not enforced).
+- **`seid config …` CLI** → once the seam is proven on a non-prod node. Thin wrappers over `Validate()`/`DefaultForMode()`; must ship a deterministic exit-code scheme (0 = clean/no-op; nonzero = validation-fail/migration-aborted; distinct code for refuse-on-newer) for initContainer/Job use.
+- **Unified `sei.toml` (Phase 3)** → after the two-file round-trip is trusted on ≥3 real fixtures for a release cycle.
+- **Migration functions** → when the first breaking change forces `CurrentVersion`→2.
+- **K8s render-at-init + secret-field enforcement** → before any env uses ConfigMap delivery (until then, secret deny-list documented, not enforced).
 - **Mode/CRD alignment** ([Appendix A](#appendix-a--modes-beyond-the-core)) → when generating `replayer` nodes is required.
-- **sei-k8s-controller / structured JSON output** → second consumer; library already exposes `ConfigIntent`.
+- **sei-k8s-controller / JSON output** → second consumer; library already exposes `ConfigIntent`.
 
 ## Open questions
 
-1. Replicate `SEI_LOG_LEVEL` extrapolation (`util.go:187-217`) in the gated path, or accept a documented behavior delta?
-2. Where does the on-disk `schema_version` live so a legacy-only checkout can be detected — managed header in `app.toml`, or only in the future `sei.toml`?
-3. Final `seid config …` command naming and flags.
+1. Replicate `SEI_LOG_LEVEL` extrapolation (`util.go:187-217`) in the gated path, or accept a documented delta?
+2. Where does on-disk `schema_version` live for legacy-only checkouts — a managed header in `app.toml`, or only the future `sei.toml`?
+3. Final `seid config …` naming/flags.
 
 ## Cross-repo coordination
 
-- **This PR (sei-config):** the design. Any library contract change (e.g. version stamping) follows as a sei-config PR, tagged for sei-chain to pin.
-- **Follow-up sei-chain PR(s):** the env-gated seam + fidelity test + collision audit; then the in-binary `seid config …` CLI.
-
-The seam PR must not merge until the collision audit passes and the fidelity test is green. The `seid config …` CLI can follow once the pinned sei-config version is tagged.
+**This PR (sei-config):** the design; any library contract change (e.g. version stamping) follows as a sei-config PR, tagged for sei-chain to pin. **Follow-up sei-chain PR(s):** the env-gated seam + fidelity test + collision audit, then the in-binary CLI. The seam PR must not merge until the collision audit passes and the fidelity test is green.
 
 ---
 
@@ -98,6 +74,11 @@ The seam PR must not merge until the collision audit passes and the fidelity tes
 
 Out of core scope; captured so the analysis isn't lost.
 
-- The deployed `SeiNode` CRD union is `validator / fullNode / archive / replayer` — it has **no `seed`** and uses **`fullNode`** (not `full`). The prototype ships `validator / full / seed / archive`.
+- The deployed `SeiNode` CRD union is `validator / fullNode / archive / replayer` — **no `seed`**, and **`fullNode`** (not `full`). The prototype ships `validator / full / seed / archive`.
 - `seed` produces operator-CLI defaults only and has no CRD target; `replayer` (mandatory snapshot + peers) is first-class in the fleet but absent from the prototype.
-- Aligning the enum — add `replayer`, reconcile `seed`, settle `full` vs `fullNode` casing — is a one-way door only on the **`generate --mode` CLI surface** (the public contract). The migration registry keys on integer version, not mode strings, so a `v1→v2` migration function can rewrite `cfg.Mode` in-place and absorb the rename cleanly. **Deferred per owner decision; un-defer when generating `replayer` nodes is required.**
+- Aligning the enum — add `replayer`, reconcile `seed`, settle `full` vs `fullNode` — is a one-way door only on the **`generate --mode` CLI surface** (the public contract). The migration registry keys on integer version, not mode strings, so a `v1→v2` migration function rewrites `cfg.Mode` in-place and absorbs the rename cleanly. **Deferred per owner decision; un-defer when generating `replayer` nodes is required.**
+
+## Appendix B — `seid config` cobra↔urfave integration
+
+- **Delegation:** one `config` cobra command with `DisableFlagParsing: true` (already used at `root.go:176,200`) hands the raw arg tail to the urfave `cli.Command`; urfave owns only the `config` subtree and never sees global cobra flags. Errors propagate via `RunE` to `main.go`'s `os.Exit`; urfave's own exit handler is a no-op.
+- **Accepted costs:** go.mod already carries urfave/cli **v2** (load-bearing in `sei-db/…/litt/cli`); v3 adds a second major version — legal, deliberate. Shell completion can't introspect a `DisableFlagParsing` subtree, so `config` subcommands won't autocomplete (deferred).


### PR DESCRIPTION
## What

A ≤2-page scoped design (`docs/config-manager/DESIGN.md`) for a **configuration manager** that routes `seid`'s config resolution through the existing `sei-config` library, behind an **off-by-default env var** (`SEI_CONFIG_MANAGER`), with a `seictl` (urfave/cli v3) management surface and a schema-versioning contract.

**This PR ships the design only.** Implementation lands as separate PRs across three repos (sei-config / sei-chain / seictl).

## Key decisions captured

- **The library is the asset; the risk is the seam.** `seiconfig` already implements the unified struct, modes, `Validate()`, the env→file registry, the (empty) migration registry, and legacy round-trip IO. Nothing calls it yet. The MVP de-risks the *seam into seid* + *round-trip fidelity against real config files*.
- **urfave/cli v3 lives in `seictl`, not in `seid`.** `seid` is cobra-rooted; two arg-parsers in one binary collide. `seid` gets only the runtime seam (pure cobra/library call); the urfave/cli v3 UX ships as the `seictl` binary. *(Flagged for reviewers to confirm first.)*
- **The seam contract is load-bearing:** the gated path must populate **both** `serverCtx.Config` (`*tmcfg.Config`) **and** `serverCtx.Viper` (AppOptions) by materializing the two legacy files and re-entering the existing Viper read+merge tail — *not* by feeding `app.New` from the in-memory struct (silent key loss). All changes stay inside the sei-chain repo proper; the `sei-cosmos` fork is untouched.
- **`SEI_` prefix collision** with `seid`'s `WithViper("SEI")` is a named must-fix (collision audit = release blocker).
- **No auto-migrate on boot**; explicit, dry-run-default, `.bak`-before-write migration.
- **Modes** kept at the prototype's four (`validator/full/seed/archive`) per owner decision; `replayer`/drop-`seed` CRD alignment deferred as a public-contract change. Modes own static role defaults only — never per-node identity, never runtime enforcement.

## MVP (first implementation PR)

> *A real `seid` home directory resolves through the library and produces a node that behaves identically to the legacy path, behind an off-by-default flag.*

In: gate + seam (both channels), collision audit, a fidelity test against a **sanitized real** `config.toml`/`app.toml`, `KNOWN_UNMAPPED_FIELDS`. Everything else (CLI, `sei.toml`, migration functions, K8s render-at-init) deferred with explicit un-defer triggers.

## Sign-off

Reviewed and signed off across four lenses: seam/integration (product-engineer — APPROVE), operational/deployment (platform-engineer — APPROVE), modes↔node-types (kubernetes-specialist — APPROVE), scope/YAGNI (product-manager — APPROVE). Two nits raised and resolved in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)