### PR TITLE
fix(defaults): async state-commit for full-mode followers (PLT-537)

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -165,6 +165,20 @@ func TestDefaultForMode_FullEnablesServices(t *testing.T) {
 	}
 }
 
+func TestDefaultForMode_AsyncCommitBufferByMode(t *testing.T) {
+	cases := map[NodeMode]int{
+		ModeFull:      100,
+		ModeArchive:   100,
+		ModeValidator: 0,
+		ModeSeed:      0,
+	}
+	for mode, want := range cases {
+		if got := DefaultForMode(mode).Storage.StateCommit.AsyncCommitBuffer; got != want {
+			t.Errorf("%s async_commit_buffer: got %d, want %d", mode, got, want)
+		}
+	}
+}
+
 func TestValidate_InvalidMode(t *testing.T) {
 	cfg := Default()
 	cfg.Mode = "bogus"

--- a/defaults.go
+++ b/defaults.go
@@ -300,6 +300,7 @@ func applyFullOverrides(cfg *SeiConfig) {
 	cfg.API.GRPCWeb.Enable = true
 	cfg.Storage.StateStore.Enable = true
 	cfg.Storage.StateStore.KeepRecent = 100_000
+	cfg.Storage.StateCommit.AsyncCommitBuffer = 100
 	cfg.Chain.MinRetainBlocks = 100_000
 
 	cfg.EVM.HTTPEnabled = true


### PR DESCRIPTION
## Problem
Full-mode followers (`node`/`rpc`/`syncer`) default to **synchronous** memIAVL commit (`sc-async-commit-buffer=0`), which holds the consensus lock `cs.mtx` across the entire block write. That starves the single-goroutine consensus **StateChannel** drain → dropped `NewRoundStep`/`HasVote` gossip → degraded peer-state view → **bistable fall-behind** (recurring `NodeFellBehind` on pacific-1). Root cause: **PLT-537**.

## Change
Default `full` mode to `AsyncCommitBuffer = 100` in `applyFullOverrides` (matches the already-async `archive` mode). Flows to full + archive (archive inherits `applyFullOverrides`); **validators and seeds stay synchronous by construction** (separate override paths) — async commit's in-memory crash window is unacceptable for a signing node.

Adds `TestDefaultForMode_AsyncCommitBufferByMode` pinning `full=100, archive=100, validator=0, seed=0` so the fix and the validator-safety constraint can't silently regress.

## Validation
- Canary on pacific-1 `node-0`: 23.7k blocks behind → tip, **0 StateChannel drops**, `block_processing` 45→29 ms, held 18 min.
- Full pacific-1 K8s follower fleet (5 nodes) recovered to tip; unchanged sync-commit nodes stayed trapped (`syncer-0-0` relapsed → restart-alone is not durable, the config is).
- EC2 `state-sync-node-0`: 32.5k → tip, `block_processing` 194→11 ms, drops → 0 (cross-topology confirmation).

## Rollout
This is a library default — it reaches prod once consumed downstream: **sei-config tag → `sei-node-controller` go.mod bump → seictl sidecar rebuild → release → rollout** (pod recreation re-renders `app.toml`). Manual `sc-async-commit-buffer=100` patches are holding the live fleet in the meantime.

## Risk
Async commit buffers un-flushed commits in memory; on an ungraceful crash the tail is re-fetched via WAL/blocksync (no corruption). Appropriate for followers/RPC/archive; explicitly **not** validators (preserved here).

Refs: PLT-537

🤖 Generated with [Claude Code](https://claude.com/claude-code)